### PR TITLE
Add video to hvPlot 0.8 blog post

### DIFF
--- a/theme/static/js/config.js
+++ b/theme/static/js/config.js
@@ -30,3 +30,7 @@ jQuery(function() {
 		detach: false
 	});
 });
+
+window.addEventListener('DOMContentLoaded', (event) => {
+    window.dispatchEvent(new Event('resize'));
+});


### PR DESCRIPTION
@philippjfr I had a look at the instructions to run create and publish the blog but couldn't quickly get an environment that would run `make html` without error. I've embedded the video in an `iframe`, it doesn't get displayed in Jupyter Lab but I was thinking that maybe it does when rendered with Pelican 🤔 