### PR TITLE
Update goatcounter URL and prefix domain

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -73,5 +73,10 @@ format:
     highlight-style: tango
     include-in-header: 
       - text: |
-          <script data-goatcounter="https://hv-blog.goatcounter.com/count" 
+          <script>
+              window.goatcounter = {
+                  path: function(p) { return location.host + p }
+              }
+          </script>
+          <script data-goatcounter="https://holoviz.goatcounter.com/count" 
           async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
To point to the new centralized dashboard (https://holoviz.goatcounter.com/) and to be prefixed with the domain name as suggested in the docs (https://www.goatcounter.com/help/domains).